### PR TITLE
fix: getUserFollowers (isCurrentUserFollowed)

### DIFF
--- a/controllers/user-controller.js
+++ b/controllers/user-controller.js
@@ -320,7 +320,7 @@ const userController = {
       const userFollowersData = followers.map(follower => ({
         ...follower.toJSON(),
         isCurrentUserFollowed:
-          follower.followerId.toString() === ThisUserId.toString()
+          follower.followingId.toString() === ThisUserId.toString()
       }))
       res.status(200).json(userFollowersData)
     } catch (err) {


### PR DESCRIPTION
修正：getUserFollowers裡面的isCurrentUserFollowed應該用following的id去作為判斷依據，而不是follower的id
![image](https://github.com/av124773/twitter-api-2020/assets/120808457/ba1e4780-e1b5-4001-878f-43ea940231fb)
