### PR TITLE
fix: filter out admin data in getTopUser

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## About The Project
 ![Alt text](image-1.png)
 
-A RESTful API server for Simple Twitter project built with React, Node.js, Express framework, and MySQL.
+A RESTful API server for Simple Twitter project built with Node.js, Express framework, and MySQL.
 
 ## Usage
 
@@ -95,7 +95,6 @@ Use the default accounts to login
 - sinon: ^10.0.0,
 - sinon-chai: ^3.3.0,
 - tslib: ^2.5.3
-- (前端開發待補上)
 
 ## Contributors
 - Kelly Ko [https://github.com/magic9701](https://github.com/magic9701)

--- a/controllers/followship-controller.js
+++ b/controllers/followship-controller.js
@@ -67,6 +67,7 @@ const followshipController = {
             followerCount: user.Followers.length,
             isFollowed: req.user.Followings.some(f => f.id === user.id)
           }))
+          .filter(user => user.role === 'user')
           .sort((a, b) => b.followerCount - a.followerCount)
           .slice(0, 10) // 只留top 10
         return res.json({ users: result })


### PR DESCRIPTION
getTopUser篩掉其它身份，只留下role === 'user'的資料，以免admin帳號顯示在推薦跟隨

<img width="1199" alt="image" src="https://github.com/av124773/twitter-api-2020/assets/120808457/2167e839-2c65-4720-bf34-062bf36f0229">
